### PR TITLE
Remind users they need to clear previous path

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Get pyenv-win via one of the following methods:
 
 
    Installation is done. Hurray!
+   
+   Note: If you installed python and added it to path before, you need to remove it from path so pyenv can manage that for you. Othervise it will seem like you are stuck to the same python version even if you change it with pyenv.
 
 ## 32bit-train Support
 


### PR DESCRIPTION
Hey,

If a user installed python before installing pyenv, python path will be set in environment variables.
Even if you add pyenv to path, python -V will be overriden by the initial python installation. Therefor pyenv can't change python versions. 

Short: Add a note to users to remind remove previous python paths.